### PR TITLE
vue example: fix context -> ctx

### DIFF
--- a/examples/vue-api/main.js
+++ b/examples/vue-api/main.js
@@ -4,11 +4,11 @@ import base from './base.vue'
 import { createHead } from '@vueuse/head'
 import { getRouter } from './router'
 
-export function createApp (context) {
+export function createApp (ctx) {
   const app = createSSRApp(base)
   const head = createHead()
   const router = getRouter()
   app.use(router)
   app.use(head)
-  return { context, app, head, router }
+  return { ctx, app, head, router }
 }


### PR DESCRIPTION
`getRender` wants `createApp` to return `ctx` not `context`, hence the PR.